### PR TITLE
Cb 79 implement trim galore subworkflow

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -39,15 +39,18 @@ process {
 
     withName: TRIMGALORE {
         ext.args = [
-            '--fastqc',
+            /*'--fastqc', gonna keep fastqc in its own module for reasons*/
+            '--illumina',
+            params.trim_quality > 0 ? "--quality ${params.trim_quality}" : '',
+            params.trim_length > 0 ? "--length  ${params.trim_length}" : '',
             params.trim_nextseq > 0 ? "--nextseq ${params.trim_nextseq}" : ''
         ].join(' ').trim()
         publishDir = [
-            [
+            /*[
                 path: { "${params.outdir}/trimgalore/fastqc" },
                 mode: 'copy',
                 pattern: "*.{html,zip}"
-            ],
+            ],*/
             [
                 path: { "${params.outdir}/trimgalore" },
                 mode: 'copy',

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -54,7 +54,7 @@ process {
             [
                 path: { "${params.outdir}/trimgalore" },
                 mode: 'copy',
-                pattern: "*.txt"
+                pattern: "*.{txt,gz,fq,fastq}"
             ]
         ]
     }

--- a/conf/test_trim_galore.config
+++ b/conf/test_trim_galore.config
@@ -1,0 +1,24 @@
+/*
+========================================================================================
+    Nextflow config file for running minimal tests
+========================================================================================
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run trim_galore.nf -profile test_trim_galore,docker
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Test profile for Trim Galore! module.'
+    config_profile_description = 'Minimal test dataset to check pipeline function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = 6.GB
+    max_time   = 6.h
+
+    // Input data
+    pairedreads = "$projectDir/localdata/*{1,2}.fq.gz" // point to fastqs
+}

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -11,18 +11,18 @@ process TRIMGALORE {
     tuple val(meta), path(reads)
 
     output:
-    //tuple val(meta), path("*{3prime,5prime,trimmed,val}*.fq.gz"), emit: reads
-    tuple val(meta), path("*fastq.gz"), emit: reads
+    tuple val(meta), path("*{3prime,5prime,trimmed,val}*.fq.gz"), emit: reads
+    // tuple val(meta), path("*fastq"), emit: reads
     tuple val(meta), path("*report.txt")                        , emit: log     , optional: true
     tuple val(meta), path("*unpaired*.fq.gz")                   , emit: unpaired, optional: true
     tuple val(meta), path("*.html")                             , emit: html    , optional: true
     tuple val(meta), path("*.zip")                              , emit: zip     , optional: true
     path "versions.yml"                                         , emit: versions
-    //TODO: reconfigure this, if trim allows for more cores (why not)
 
     when:
     task.ext.when == null || task.ext.when
 
+    //TODO: reconfigure this, if trim allows for more cores (why not)
     script:
     def args = task.ext.args ?: ''
     // Calculate number of --cores for TrimGalore based on value of task.cpus
@@ -39,7 +39,7 @@ process TRIMGALORE {
     // Added soft-links to original fastqs for consistent naming in MultiQC
     def prefix = task.ext.prefix ?: "${meta.id}"
     // tolerate not gzipped fastqs
-    def gzswitch = reads[0].toString().endsWith(".gz") ? ".gz" : ""
+    def gzswitch = reads[0].toString().endsWith(".gz") ? ".gz" : ".gz"
     """
     [ ! -f  ${prefix}_1.fastq${gzswitch} ] && ln -s ${reads[0]} ${prefix}_1.fastq${gzswitch}
     [ ! -f  ${prefix}_2.fastq${gzswitch} ] && ln -s ${reads[1]} ${prefix}_2.fastq${gzswitch}

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -12,7 +12,6 @@ process TRIMGALORE {
 
     output:
     tuple val(meta), path("*{3prime,5prime,trimmed,val}*.fq.gz"), emit: reads
-    // tuple val(meta), path("*fastq"), emit: reads
     tuple val(meta), path("*report.txt")                        , emit: log     , optional: true
     tuple val(meta), path("*unpaired*.fq.gz")                   , emit: unpaired, optional: true
     tuple val(meta), path("*.html")                             , emit: html    , optional: true
@@ -22,7 +21,6 @@ process TRIMGALORE {
     when:
     task.ext.when == null || task.ext.when
 
-    //TODO: reconfigure this, if trim allows for more cores (why not)
     script:
     def args = task.ext.args ?: ''
     // Calculate number of --cores for TrimGalore based on value of task.cpus
@@ -39,7 +37,7 @@ process TRIMGALORE {
     // Added soft-links to original fastqs for consistent naming in MultiQC
     def prefix = task.ext.prefix ?: "${meta.id}"
     // tolerate not gzipped fastqs
-    def gzswitch = reads[0].toString().endsWith(".gz") ? ".gz" : ".gz"
+    def gzswitch = reads[0].toString().endsWith(".gz") ? ".gz" : ""
     """
     [ ! -f  ${prefix}_1.fastq${gzswitch} ] && ln -s ${reads[0]} ${prefix}_1.fastq${gzswitch}
     [ ! -f  ${prefix}_2.fastq${gzswitch} ] && ln -s ${reads[1]} ${prefix}_2.fastq${gzswitch}

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,8 @@ params {
     skip_fastqc                 = false
 
     // Trimming options
+    trim_quality                = 20
+    trim_length                 = 50
     clip_r1                     = null
     clip_r2                     = null
     three_prime_clip_r1         = null

--- a/trim_galore.nf
+++ b/trim_galore.nf
@@ -1,4 +1,4 @@
-// Bowtie 2 Bos taurus alignment and filtering
+// Trim Galore! Illumina adapter trimming
 // Taylor Falk tfalk@arkeabio.com
 // Arkea Bio Corp, May 2023
 

--- a/trim_galore.nf
+++ b/trim_galore.nf
@@ -1,0 +1,18 @@
+// Bowtie 2 Bos taurus alignment and filtering
+// Taylor Falk tfalk@arkeabio.com
+// Arkea Bio Corp, May 2023
+
+include { TRIMGALORE } from './modules/nf-core/trimgalore/'
+
+read_ch = Channel.fromFilePairs(params.pairedreads, checkIfExists: true)
+
+read_ch.view()
+
+workflow TRIMMYTRIM {
+    reads = read_ch.map  { [[id: 'test'], it[1]]}
+    TRIMGALORE(reads)
+}
+
+workflow  {
+    TRIMMYTRIM()
+}


### PR DESCRIPTION
Another day another module! Trim Galore has been implemented as a stand alone process (instead of an included FastQC option, much better for our design and readability).  

Give the test config a test with `nextflow run trim_galore.nf -profile test_trim_galore,docker`. You can also specify parameters on the command line with `nextflow run trim_galore.nf -profile docker --pairedreads "localdata/*{1,2}*.fq.gz"`.

I added functionality to the main nf-core module to accept both gzipped and uncompressed fastq files, so please try to test both of the read pairs in `localdata/`.  

One interesting bug to squash was that Trim Galore! wasn't spitting its trimmed reads into the `results/` folder. Normally this is fine since the trimmed reads are always transformed later on in the pipeline. However, as a stand alone tool I didn't like this behavior. Turned out the issue lay in the `modules.config` file, which describes parameters for each tool. It was filtering results to only capture `.txt` files. Useful if a user just wants to check logs, but if we want those tasty fastqs we have to change this!

This kind of functionality will likely be useful once we spend time polishing the pipeline and don't want to crowd our results, but another example of the esotericism Nextflow utilizes; a little config file left me head scratching for a couple hours. Fun!
---
`modules.config` by default:  
![image](https://github.com/Arkea-Bio-Corp/metatdenovo/assets/131815442/0a51d171-5363-4f56-8f11-bf6b320111a1)
My changes to `module.config`:  
![image](https://github.com/Arkea-Bio-Corp/metatdenovo/assets/131815442/61ae9be9-a947-431e-9815-ed72ffcb33d0)
