### PR TITLE
Cb 82 modify bbduk module to create dedupe module

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -59,6 +59,22 @@ process {
         ]
     }
 
+    withName: BBMAP_DEDUPE {
+        ext.args = "ac=f"
+        publishDir = [
+            [
+                path: { "${params.outdir}/bbmap/dedupe" },
+                mode: 'copy',
+                pattern: "*.{gz,fq,fastq}",
+            ],
+            [
+                path: { "${params.outdir}/bbmap/dedupe/logs" },
+                mode: 'copy',
+                pattern: "*.log"
+            ]
+        ]
+    }
+
     withName: SEQTK_MERGEPE {
         publishDir = [
             enabled: false

--- a/conf/test_dedupe.config
+++ b/conf/test_dedupe.config
@@ -5,13 +5,13 @@
     Defines input files and everything required to run a fast and simple pipeline test.
 
     Use as follows:
-        nextflow run trim_galore.nf -profile test_trim_galore,docker
+        nextflow run dedupe.nf -profile test_dedupe,docker
 
 ----------------------------------------------------------------------------------------
 */
 
 params {
-    config_profile_name        = 'Test profile for Trim Galore! module.'
+    config_profile_name        = 'Test profile for dedupe module.'
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
     // Limit resources so that this can run on GitHub Actions
@@ -20,5 +20,5 @@ params {
     max_time   = 6.h
 
     // Input data
-    pairedreads = "$projectDir/localdata/*{1,2}.fq.gz" // point to fastqs
+    pairedreads = "$projectDir/localdata/*{1,2}.fastq.gz" // point to fastqs
 }

--- a/conf/test_dedupe.config
+++ b/conf/test_dedupe.config
@@ -1,0 +1,24 @@
+/*
+========================================================================================
+    Nextflow config file for running minimal tests
+========================================================================================
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run trim_galore.nf -profile test_trim_galore,docker
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Test profile for Trim Galore! module.'
+    config_profile_description = 'Minimal test dataset to check pipeline function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = 6.GB
+    max_time   = 6.h
+
+    // Input data
+    pairedreads = "$projectDir/localdata/*{1,2}.fq.gz" // point to fastqs
+}

--- a/dedupe.nf
+++ b/dedupe.nf
@@ -1,0 +1,18 @@
+// Trim Galore! Illumina adapter trimming
+// Taylor Falk tfalk@arkeabio.com
+// Arkea Bio Corp, May 2023
+
+include { TRIMGALORE } from './modules/nf-core/trimgalore/'
+
+read_ch = Channel.fromFilePairs(params.pairedreads, checkIfExists: true)
+
+read_ch.view()
+
+workflow TRIMMYTRIM {
+    reads = read_ch.map  { [[id: 'test'], it[1]]}
+    TRIMGALORE(reads)
+}
+
+workflow  {
+    TRIMMYTRIM()
+}

--- a/dedupe.nf
+++ b/dedupe.nf
@@ -1,18 +1,18 @@
-// Trim Galore! Illumina adapter trimming
-// Taylor Falk tfalk@arkeabio.com
+// Dedupe - deduplication of sequencing reads
+// Laura Holland lholland@arkeabio.com
 // Arkea Bio Corp, May 2023
 
-include { TRIMGALORE } from './modules/nf-core/trimgalore/'
+include { BBMAP_DEDUPE } from './modules/nf-core/bbmap/dedupe/'
 
 read_ch = Channel.fromFilePairs(params.pairedreads, checkIfExists: true)
 
 read_ch.view()
 
-workflow TRIMMYTRIM {
+workflow DEDUPE {
     reads = read_ch.map  { [[id: 'test'], it[1]]}
-    TRIMGALORE(reads)
+    BBMAP_DEDUPE(reads)
 }
 
 workflow  {
-    TRIMMYTRIM()
+    DEDUPE()
 }

--- a/dedupe.nf
+++ b/dedupe.nf
@@ -1,18 +1,18 @@
-// Trim Galore! Illumina adapter trimming
-// Taylor Falk tfalk@arkeabio.com
+// Dedupe - deduplication of sequencing reads
+// Laura Holland lholland@arkeabio.com
 // Arkea Bio Corp, May 2023
 
-include { TRIMGALORE } from './modules/nf-core/trimgalore/'
+include { BBMAP_DEDUPE } from './modules/nf-core/bbmap/dedupe'
 
 read_ch = Channel.fromFilePairs(params.pairedreads, checkIfExists: true)
 
 read_ch.view()
 
-workflow TRIMMYTRIM {
+workflow DEDUPE {
     reads = read_ch.map  { [[id: 'test'], it[1]]}
-    TRIMGALORE(reads)
+    BBMAP_DEDUPE(reads)
 }
 
 workflow  {
-    TRIMMYTRIM()
+    DEDUPE()
 }

--- a/dedupe.nf
+++ b/dedupe.nf
@@ -1,18 +1,18 @@
-// Dedupe - deduplication of sequencing reads
-// Laura Holland lholland@arkeabio.com
+// Trim Galore! Illumina adapter trimming
+// Taylor Falk tfalk@arkeabio.com
 // Arkea Bio Corp, May 2023
 
-include { BBMAP_DEDUPE } from './modules/nf-core/bbmap/dedupe'
+include { TRIMGALORE } from './modules/nf-core/trimgalore/'
 
 read_ch = Channel.fromFilePairs(params.pairedreads, checkIfExists: true)
 
 read_ch.view()
 
-workflow DEDUPE {
+workflow TRIMMYTRIM {
     reads = read_ch.map  { [[id: 'test'], it[1]]}
-    BBMAP_DEDUPE(reads)
+    TRIMGALORE(reads)
 }
 
 workflow  {
-    DEDUPE()
+    TRIMMYTRIM()
 }

--- a/modules/nf-core/bbmap/dedupe/main.nf
+++ b/modules/nf-core/bbmap/dedupe/main.nf
@@ -22,11 +22,10 @@ process BBMAP_DEDUPE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def all_reads      = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
-    def deduped_reads  = meta.single_end ? "out=${prefix}.fastq.gz" : "out1=${prefix}_1.fastq.gz out2=${prefix}_2.fastq.gz"
+    def deduped_reads  = meta.single_end ? "out=${prefix}.fastq.gz" : "out=${prefix}_deduped.fastq.gz"
     """
-    maxmem=\$(echo \"$task.memory\"| sed 's/ GB/g/g')
     dedupe.sh \\
-        -Xmx\$maxmem \\
+        -Xmx${task.memory.toGiga()}g \\
         $all_reads \\
         $deduped_reads \\
         threads=$task.cpus \\

--- a/modules/nf-core/bbmap/dedupe/main.nf
+++ b/modules/nf-core/bbmap/dedupe/main.nf
@@ -21,12 +21,12 @@ process BBMAP_DEDUPE {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def all_reads      = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
-    def deduped_reads  = meta.single_end ? "out=${prefix}.fastq.gz" : "out1=${prefix}_1.fastq.gz out2=${prefix}_2.fastq.gz"
+    def all_reads      = meta.single_end ? "in=${reads[0]}" : "in=${reads[0]} in2=${reads[1]}"
+    def deduped_reads  = meta.single_end ? "out=${prefix}.fastq.gz" : "out=${prefix}_deduped.fastq.gz"
+
     """
-    maxmem=\$(echo \"$task.memory\"| sed 's/ GB/g/g')
     dedupe.sh \\
-        -Xmx\$maxmem \\
+        -Xmx${task.memory.toGiga()}g \\
         $all_reads \\
         $deduped_reads \\
         threads=$task.cpus \\

--- a/modules/nf-core/bbmap/dedupe/main.nf
+++ b/modules/nf-core/bbmap/dedupe/main.nf
@@ -1,6 +1,6 @@
 process BBMAP_DEDUPE {
     tag "$meta.id"
-    label 'process_medium'
+    label 'process_macbook'
 
     conda "bioconda::bbmap=39.01"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/bbmap/dedupe/main.nf
+++ b/modules/nf-core/bbmap/dedupe/main.nf
@@ -21,12 +21,12 @@ process BBMAP_DEDUPE {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def all_reads      = meta.single_end ? "in=${reads[0]}" : "in=${reads[0]} in2=${reads[1]}"
-    def deduped_reads  = meta.single_end ? "out=${prefix}.fastq.gz" : "out=${prefix}_deduped.fastq.gz"
-
+    def all_reads      = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
+    def deduped_reads  = meta.single_end ? "out=${prefix}.fastq.gz" : "out1=${prefix}_1.fastq.gz out2=${prefix}_2.fastq.gz"
     """
+    maxmem=\$(echo \"$task.memory\"| sed 's/ GB/g/g')
     dedupe.sh \\
-        -Xmx${task.memory.toGiga()}g \\
+        -Xmx\$maxmem \\
         $all_reads \\
         $deduped_reads \\
         threads=$task.cpus \\

--- a/modules/nf-core/bbmap/dedupe/main.nf
+++ b/modules/nf-core/bbmap/dedupe/main.nf
@@ -1,0 +1,40 @@
+process BBMAP_DEDUPE {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "bioconda::bbmap=39.01"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bbmap:39.01--h5c4e2a8_0':
+        'quay.io/biocontainers/bbmap:39.01--h5c4e2a8_0' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path('*.fastq.gz'), emit: reads
+    tuple val(meta), path('*.log')     , emit: log
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def all_reads      = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
+    def deduped_reads  = meta.single_end ? "out=${prefix}.fastq.gz" : "out1=${prefix}_1.fastq.gz out2=${prefix}_2.fastq.gz"
+    """
+    maxmem=\$(echo \"$task.memory\"| sed 's/ GB/g/g')
+    dedupe.sh \\
+        -Xmx\$maxmem \\
+        $all_reads \\
+        $deduped_reads \\
+        threads=$task.cpus \\
+        $args \\
+        &> ${prefix}.dedupe.log
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bbmap/dedupe/meta.yml
+++ b/modules/nf-core/bbmap/dedupe/meta.yml
@@ -1,0 +1,52 @@
+name: bbmap_bbduk
+description: Adapter and quality trimming of sequencing reads
+keywords:
+  - trimming
+  - adapter trimming
+  - quality trimming
+  - fastq
+tools:
+  - bbmap:
+      description: BBMap is a short read aligner, as well as various other bioinformatic tools.
+      homepage: https://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/
+      documentation: https://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/
+
+      licence: ["UC-LBL license (see package)"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - contaminants:
+      type: file
+      description: |
+        Reference files containing adapter and/or contaminant sequences for sequence kmer matching
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: The trimmed/modified fastq reads
+      pattern: "*fastq.gz"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - log:
+      type: file
+      description: Bbduk log file
+      pattern: "*bbduk.log"
+
+authors:
+  - "@MGordon09"

--- a/modules/nf-core/bbmap/dedupe/meta.yml
+++ b/modules/nf-core/bbmap/dedupe/meta.yml
@@ -1,9 +1,7 @@
-name: bbmap_bbduk
-description: Adapter and quality trimming of sequencing reads
+name: bbmap_dedupe
+description: Deduplication of sequencing reads
 keywords:
-  - trimming
-  - adapter trimming
-  - quality trimming
+  - deduplication
   - fastq
 tools:
   - bbmap:
@@ -24,10 +22,6 @@ input:
       description: |
         List of input FastQ files of size 1 and 2 for single-end and paired-end data,
         respectively.
-  - contaminants:
-      type: file
-      description: |
-        Reference files containing adapter and/or contaminant sequences for sequence kmer matching
 
 output:
   - meta:
@@ -37,16 +31,17 @@ output:
         e.g. [ id:'test', single_end:false ]
   - reads:
       type: file
-      description: The trimmed/modified fastq reads
-      pattern: "*fastq.gz"
+      description: The deduplicated fastq reads
+      pattern: "*.{fq,fastq,gz}"
   - versions:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
   - log:
       type: file
-      description: Bbduk log file
-      pattern: "*bbduk.log"
+      description: Dedupe log file
+      pattern: "*dedupe.log"
 
 authors:
   - "@MGordon09"
+  - "@lzholl"

--- a/nextflow.config
+++ b/nextflow.config
@@ -192,6 +192,8 @@ profiles {
     test_eggnog         { includeConfig 'conf/test_eggnog.config'       }
     test_eukulele       { includeConfig 'conf/test_eukulele.config'     }
     test_rnaspades      { includeConfig 'conf/test_rnaspades.config'    }
+    test_trim_galore    { includeConfig 'conf/test_trim_galore.config'  }
+    test_dedupe         { includeConfig 'conf/test_dedupe.config'       }
     gitpod {
         executor.name          = 'local'
         executor.cpus          = 16


### PR DESCRIPTION
Modified the bbmap_bbduk module to create the bbmap_dedupe module. 

Test with either `nextflow run dedupe.nf -profile test_dedupe,docker` or by adding the parameters to the command line with `nextflow run dedupe.nf -profile test_dedupe,docker --pairedreads "localdata/*{1,2}.fastq.gz"`. It should be able to use both  compressed and not compressed fastq files, so please test both. The output should be 1 file with the paired reads interleaved (which should be fine for our purposes).

Also added the test_trim_galore profile because apparently it was missing. Didn't catch it before since I ran it the second way. 