### PR TITLE
Cb 81 update modules config file with selected parameters

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -59,12 +59,12 @@ process {
         ]
     }
 
-    withName: SORTMERNA{
+    withName: SORTMERNA {
         publishDir = [
             [
                 path: { "${params.outdir}/sortmerna" },
                 mode: 'copy',
-                pattern: "*.{gz,fq,fastq}",
+                pattern: "*.{gz,fq,fastq}"
             ],
             [
                 path: { "${params.outdir}/sortmerna/logs" },
@@ -80,7 +80,7 @@ process {
             [
                 path: { "${params.outdir}/bbmap/dedupe" },
                 mode: 'copy',
-                pattern: "*.{gz,fq,fastq}",
+                pattern: "*.{gz,fq,fastq}"
             ],
             [
                 path: { "${params.outdir}/bbmap/dedupe/logs" },
@@ -95,7 +95,7 @@ process {
             '–use-names',
             '–report-zero-counts',
             params.confidence > 0 ? "-confidence ${params.confidence}" : ''
-        ].join(' ').trim(),
+        ].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/kraken2" },
             mode: 'copy',
@@ -121,12 +121,11 @@ process {
             params.percent_seq_id > 0 ? "-c ${params.percent_seq_id}" : '',
             params.word_length > 0 ? "-n  ${params.word_length}" : ''
         ].join(' ').trim()
-        publishDir = 
-            [
-                path: { "${params.outdir}/cdhit" },
-                mode: 'copy',
-                pattern: "*.{fa,fasta,clstr}"
-            ]
+        publishDir = [
+            path: { "${params.outdir}/cdhit" },
+            mode: 'copy',
+            pattern: "*.{fa,fasta,clstr}"
+        ]
     }
 
     withName: 'SALMON_INDEX' {
@@ -139,13 +138,15 @@ process {
 
     withName: 'SALMON_QUANT' {
         publishDir = [
-            path: { "${params.outdir}/salmon/quant/results" },
-            mode: params.publish_dir_mode
-        ],
-        publishDir = [
-            path: { "${params.outdir}/salmon/quant" },
-            mode: 'copy',
-            pattern: "*info.json"
+            [
+                path: { "${params.outdir}/salmon/quant/results" },
+                mode: params.publish_dir_mode
+            ],
+            [
+                path: { "${params.outdir}/salmon/quant" },
+                mode: 'copy',
+                pattern: "*info.json"
+            ]
         ]
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -59,6 +59,21 @@ process {
         ]
     }
 
+    withName: SORTMERNA{
+        publishDir = [
+            [
+                path: { "${params.outdir}/sortmerna" },
+                mode: 'copy',
+                pattern: "*.{gz,fq,fastq}",
+            ],
+            [
+                path: { "${params.outdir}/sortmerna/logs" },
+                mode: 'copy',
+                pattern: "*.log"
+            ]
+        ]
+    }
+
     withName: BBMAP_DEDUPE {
         ext.args = "ac=f"
         publishDir = [
@@ -75,143 +90,21 @@ process {
         ]
     }
 
-    withName: SEQTK_MERGEPE {
-        publishDir = [
-            enabled: false
-        ]
-    }
-
-    withName: KHMER_NORMALIZEBYMEDIAN {
-        ext.args = [
-            params.diginorm_C ? "-C ${params.diginorm_C}" : '',
-            params.diginorm_k ? "-k ${params.diginorm_k}" : '',
-        ].join(' ').trim()
-        publishDir = [
+        withName: KRAKEN2_KRAKEN2 {
+            ext.args = [
+                '–use-names',
+                '–report-zero-counts',
+                params.confidence > 0 ? "--nextseq ${params.trim_nextseq}" : ''
+            ].join(' ').trim(),
+            publishDir = [
             [
-                path: { "${params.outdir}/diginorm" },
+                path: { "${params.outdir}/kraken2" },
                 mode: 'copy',
-                pattern: "*.fastq.gz"
-            ],
-            [
-                path: { "${params.outdir}/diginorm/logs" },
-                mode: 'copy',
-                pattern: "*.log"
+                pattern: "*.{txt,gz,fq,fastq}",
             ]
         ]
     }
 
-    withName: KHMER_FILTERABUND {
-        ext.args = [
-            '--variable-coverage',
-            params.diginorm_C ? "-C ${params.diginorm_C} -Z ${params.diginorm_C}" : '',
-            ].join(' ').trim()
-        publishDir = [
-            [
-                path: { "${params.outdir}/diginorm" },
-                mode: 'copy',
-                pattern: "*.fastq.gz"
-            ],
-            [
-                path: { "${params.outdir}/diginorm/logs" },
-                mode: 'copy',
-                pattern: "*.log"
-            ]
-        ]
-    }
-
-    withName: KHMER_EXTRACTPAIREDREADS {
-        publishDir = [
-            [
-                path: { "${params.outdir}/diginorm" },
-                mode: 'copy',
-                pattern: "*.fastq.gz"
-            ],
-            [
-                path: { "${params.outdir}/diginorm/logs" },
-                mode: 'copy',
-                pattern: "*.log"
-            ]
-        ]
-    }
-
-    withName: BBMAP_BBNORM {
-        ext.args = [
-            params.bbnorm_target ? "target=${params.bbnorm_target}" : '',
-            params.bbnorm_min    ? "min=${params.bbnorm_min}" : '',
-        ].join(' ').trim()
-        publishDir = [
-            [
-                path : { "${params.outdir}/bbmap/bbnorm/logs" },
-                mode : 'copy',
-                pattern: "*.log"
-            ],
-            [
-                path : { "${params.outdir}/bbmap/bbnorm/"},
-                mode : 'copy',
-                pattern: "*.fastq.gz",
-                enabled: params.save_bam
-            ]
-        ]
-    }
-
-    withName: MEGAHIT_INTERLEAVED {
-        publishDir = [
-            path: { "${params.outdir}/megahit" },
-            mode: 'copy',
-            pattern: '**/*.{gz,log}'
-        ]
-    }
-
-    withName: BBMAP_INDEX {
-        publishDir = [
-            enabled: false
-        ]
-    }
-
-    withName: BBMAP_ALIGN {
-        ext.args = "trimreaddescriptions=t pigz=t"
-        publishDir = [
-            [
-                path: { "${params.outdir}/bbmap/bam" },
-                mode: 'copy',
-                pattern: "*.bam",
-                enabled: params.save_bam
-            ],
-            [
-                path: { "${params.outdir}/bbmap/logs" },
-                mode: 'copy',
-                pattern: "*.log"
-            ]
-        ]
-    }
-
-    withName: SAMTOOLS_SORT {
-        ext.prefix = { "${meta.id}.sorted" }
-    }
-
-    withName: PRODIGAL {
-        ext.args = params.prodigal_trainingfile ? "-t $params.prodigal_trainingfile" : "-p meta"
-        publishDir = [
-            path: { "${params.outdir}/prodigal" },
-            mode: 'copy',
-            pattern: "*.gz"
-        ]
-    }
-
-    withName: FORMAT_PRODIGAL_GFF {
-        publishDir = [
-            path: { "${params.outdir}/prodigal" },
-            mode: 'copy',
-            pattern: "*.gz"
-        ]
-    }
-
-    withName: 'PROKKA' {
-        ext.args = '--prodigal --metagenome'
-        publishDir = [
-            enabled: false
-        ]
-    }
 
     withName: 'FAA_CAT' {
         ext.prefix = 'prokka.faa.gz'
@@ -235,23 +128,6 @@ process {
         ext.prefix = 'prokka.gff.gz'
         publishDir = [
             path: { "${params.outdir}/prokka" },
-            mode: 'copy',
-            pattern: "*.gz"
-        ]
-    }
-
-    withName: '.*:FEATURECOUNTS_CDS' {
-        ext.args = '-g ID -t CDS -F gtf'
-        publishDir = [
-            path: { "${params.outdir}/featurecounts" },
-            mode: 'copy',
-            pattern: "*.featureCounts.*"
-        ]
-    }
-
-    withName: COLLECT_FEATURECOUNTS {
-        publishDir = [
-            path: { "${params.outdir}/summary_tables" },
             mode: 'copy',
             pattern: "*.gz"
         ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -90,21 +90,79 @@ process {
         ]
     }
 
-        withName: KRAKEN2_KRAKEN2 {
-            ext.args = [
-                '–use-names',
-                '–report-zero-counts',
-                params.confidence > 0 ? "--nextseq ${params.trim_nextseq}" : ''
-            ].join(' ').trim(),
-            publishDir = [
-            [
-                path: { "${params.outdir}/kraken2" },
-                mode: 'copy',
-                pattern: "*.{txt,gz,fq,fastq}",
-            ]
+    withName: KRAKEN2_KRAKEN2 {
+        ext.args = [
+            '–use-names',
+            '–report-zero-counts',
+            params.confidence > 0 ? "-confidence ${params.confidence}" : ''
+        ].join(' ').trim(),
+        publishDir = [
+            path: { "${params.outdir}/kraken2" },
+            mode: 'copy',
+            pattern: "*.{txt,gz,fq,fastq}"
         ]
     }
 
+    withName: TRINITY {
+        ext.args = [
+            '–-verbose',
+            '--run_as_paired',
+            params.min_contig_length > 0 ? "--min_contig_length ${params.min_contig_length}" : ''
+        ].join(' ').trim()
+        publishDir = [
+            path: { "${params.outdir}/trinity" },
+            mode: 'copy',
+            pattern: "*.{gz,fa,fasta}"
+        ]
+    }
+
+    withName: CDHIT_CDHIT {
+        ext.args = [
+            params.percent_seq_id > 0 ? "-c ${params.percent_seq_id}" : '',
+            params.word_length > 0 ? "-n  ${params.word_length}" : ''
+        ].join(' ').trim()
+        publishDir = 
+            [
+                path: { "${params.outdir}/cdhit" },
+                mode: 'copy',
+                pattern: "*.{fa,fasta,clstr}"
+            ]
+    }
+
+    withName: 'SALMON_INDEX' {
+        publishDir = [
+            path: { "${params.outdir}/salmon/index" },
+            mode: 'copy',
+            pattern: "*.{bin,json,log,tsv}"
+        ]
+    }
+
+    withName: 'SALMON_QUANT' {
+        publishDir = [
+            path: { "${params.outdir}/salmon/quant/results" },
+            mode: params.publish_dir_mode
+        ],
+        publishDir = [
+            path: { "${params.outdir}/salmon/quant" },
+            mode: 'copy',
+            pattern: "*info.json"
+        ]
+    }
+
+    withName: 'TRANSDECODER_LONGORF' {
+        publishDir = [
+            path: { "${params.outdir}/transdecoder/longorf" },
+            mode: params.publish_dir_mode
+        ]
+    }
+
+    withName: 'TRANSDECODER_PREDICT' {
+        publishDir = [
+            path: { "${params.outdir}/transdecoder/predict" },
+            mode: 'copy',
+            pattern: "*.transdecoder.{pep,cds,gff3,bed}"
+        ]
+    }
 
     withName: 'FAA_CAT' {
         ext.prefix = 'prokka.faa.gz'

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,24 +28,15 @@ params {
     save_trimmed                = false
     skip_trimming               = false
 
-    // BBmap options
-    sequence_filter             = null
-    save_bam                    = false
+    // Kraken2 options
+    confidence                  = 0.5
 
-    // Digital normalization options
-    bbnorm                      = false
-    bbnorm_target               = 100
-    bbnorm_min                  = 5
-    diginorm                    = false
-    diginorm_C                  = 20
-    diginorm_k                  = 20
+    // Trinity options
+    min_contig_length           = 200
 
-    // assembler option
-    assembler                   = 'megahit'
-
-    // orf caller options
-    orf_caller                  = 'prodigal'
-    prodigal_trainingfile       = null
+    // CD-HIT(-EST) options
+    percent_seq_id              = 0.98
+    word_length                 = 10
 
     // HMMSEARCH options
     hmmdir                      = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -47,22 +47,12 @@ params {
     eggnog_dbpath               = "./eggnog/"
     skip_eggnog                 = false
 
-    // KOfamscan options
-    skip_kofamscan              = false
-    kofam_dir                   = './kofam'
-
     // CAT
     cat                         = false
     cat_db                      = null
     cat_db_generate             = false
     cat_official_taxonomy       = false
     save_cat_db                 = false
-
-    // Eukulele options
-    eukulele_db                 = null
-    skip_eukulele               = false
-    eukulele_dbpath             = './eukulele'
-    eukulele_method             = 'mets'
 
     // MultiQC options
     multiqc_config             = null
@@ -86,7 +76,6 @@ params {
     show_hidden_params         = false
     schema_ignore_params       = 'genomes'
 
-
     // Config options
     custom_config_version      = 'master'
     custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
@@ -94,7 +83,6 @@ params {
     config_profile_contact     = null
     config_profile_url         = null
     config_profile_name        = null
-
 
     // Max resource options
     // Defaults only, expecting to be overwritten


### PR DESCRIPTION
Okay! The `nextflow.config` and `modules.config` files should be all set for the modules we will be using. I removed the module configs & params that we shouldn't need, too.

I used the global parameter `publish_dir_mode` for modules that may have multiple folders for outputs. It's currently sent to `'copy'` mode so we can get all the outputs during testing. We'll want to change/disable that eventually, as we'll likely need very few final outputs.

I tried testing one of the modules just by using its `main.nf` file, but nextflow didn't like that it's not part of a workflow. We've yet to make workflows for the modules I've added though, so the module configs will have to be adjusted as we go. But at least the base code there! It was also throwing a parsing error when I first started testing it, so I had to track down all the brackets. 😒 But the result is clean code, yay!