### PR TITLE
CB-117 set up the extremely straightforward CD HIT EST module

### DIFF
--- a/cd_hit_est.nf
+++ b/cd_hit_est.nf
@@ -1,0 +1,17 @@
+// CD-HIT-EST protein clustering
+// Taylor Falk tfalk@arkeabio.com
+// Arkea Bio Corp, May 2023
+
+include { CDHIT_CDHIT } from './modules/nf-core/cdhit/'
+
+read_ch = Channel.fromPath(params.fasta, checkIfExists: true)
+read_ch.view()
+
+workflow CDHITEST {
+    reads = read_ch.map  { [[id: 'test'], it]}
+    CDHIT_CDHIT(reads)
+}
+
+workflow  {
+    CDHITEST()
+}

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -119,8 +119,8 @@ process {
 
     withName: CDHIT_CDHIT {
         ext.args = [
-            params.percent_seq_id > 0 ? "-c ${params.percent_seq_id}" : '',
-            params.word_length > 0 ? "-n  ${params.word_length}" : ''
+            params.percent_seq_id !== 0.9 ? "-c ${params.percent_seq_id}" : '',
+            params.word_length !== 10 ? "-n  ${params.word_length}" : ''
         ].join(' ').trim()
         publishDir = [
             path: { "${params.outdir}/cdhit" },

--- a/conf/test_cd_hit_est.config
+++ b/conf/test_cd_hit_est.config
@@ -1,0 +1,24 @@
+/*
+========================================================================================
+    Nextflow config file for running minimal tests
+========================================================================================
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run cd_hit_est.nf -profile test_cd_hit_est,docker
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Test profile for CD HIT EST. Uses Trinity output fa.'
+    config_profile_description = 'Minimal test dataset to check pipeline function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = 10.GB
+    max_time   = 1.h
+
+    // Trinity output used as input:
+    fasta = "$projectDir/localdata/trinity_out.fa" 
+}

--- a/modules/nf-core/cdhit/main.nf
+++ b/modules/nf-core/cdhit/main.nf
@@ -1,11 +1,11 @@
 process CDHIT_CDHIT {
     tag "$meta.id"
-    label 'process_medium'
+    label 'process_macbook'
 
     conda "bioconda::cd-hit=4.8.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/cd-hit%3A4.8.1--h5b5514e_7':
-        'biocontainers/cd-hit:4.8.1--h5b5514e_7' }"
+        'quay.io/biocontainers/cd-hit:4.8.1--h5b5514e_7' }"
 
     input:
     tuple val(meta), path(sequences)
@@ -22,11 +22,12 @@ process CDHIT_CDHIT {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    cd-hit \\
+    cd-hit-est \\
         -i $sequences \\
         -o ${prefix}.fasta \\
         -M $task.memory.mega \\
-        -T $task.cpus
+        -T $task.cpus \\
+        $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -172,6 +172,7 @@ profiles {
     test                { includeConfig 'conf/test.config'              }
     test_filter         { includeConfig 'conf/test_filter.config'       }
     test_bowtie         { includeConfig 'conf/test_bowtie.config'       }
+    test_cd_hit_est     { includeConfig 'conf/test_cd_hit_est.config'   }
     test_sortmerna      { includeConfig 'conf/test_sortmerna.config'    }
     test_diginorm       { includeConfig 'conf/test_diginorm.config'     }
     test_full           { includeConfig 'conf/test_full.config'         }


### PR DESCRIPTION
A straightforward one!

Test data is a [random Trinity output fasta](https://drive.google.com/file/d/1-ZMJ8qJ4f5BvFgPKwbjZw9fgzmi40ftE/view?usp=share_link) I grabbed from my own testing.

As always, give it a try with:
```
nextflow run cd_hit_est.nf -profile test_cd_hit_est,docker
```
or
```
nextflow run cd_hit_est.nf -profile docker --fasta "localdata/trinity_out.fa"
```