### PR TITLE
Cb 119 salmon module for quanitification

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -106,8 +106,8 @@ process {
 
     withName: KRAKEN2_KRAKEN2 {
         ext.args = [
-            '–use-names',
-            '–report-zero-counts',
+            '-use-names',
+            '-report-zero-counts',
             params.confidence > 0 ? "-confidence ${params.confidence}" : ''
         ].join(' ').trim()
         publishDir = [
@@ -133,7 +133,8 @@ process {
         publishDir = [
             path: { "${params.outdir}/salmon/index" },
             mode: 'copy',
-            pattern: "*.{bin,json,log,tsv}"
+            pattern: "*"
+            // pattern: "*/*.{bin,json,log,tsv}"
         ]
     }
 

--- a/conf/test_salmon.config
+++ b/conf/test_salmon.config
@@ -1,0 +1,25 @@
+/*
+========================================================================================
+    Nextflow config file for running minimal tests
+========================================================================================
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run salmon.nf -profile test_salmon,docker
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Test profile for Salmon module. Index + quant.'
+    config_profile_description = 'Minimal test dataset to check pipeline function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = 10.GB
+    max_time   = 1.h
+
+    // Input data, teeny fastqs/fastas from Trinity test GitHub
+    pairedreads   = "$projectDir/localdata/reads/sub_SRR18336222_{1,2}.fastq"
+    transcriptome = "$projectDir/localdata/trinity_out.fa" 
+}

--- a/modules/nf-core/salmon/index/main.nf
+++ b/modules/nf-core/salmon/index/main.nf
@@ -1,14 +1,13 @@
 process SALMON_INDEX {
     tag "$transcript_fasta"
-    label "process_medium"
+    label "process_macbook"
 
     conda "bioconda::salmon=1.10.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/salmon:1.10.1--h7e5ed60_0' :
-        'biocontainers/salmon:1.10.1--h7e5ed60_0' }"
+        'quay.io/biocontainers/salmon:1.10.1--h7e5ed60_0' }"
 
     input:
-    path genome_fasta
     path transcript_fasta
 
     output:
@@ -20,24 +19,12 @@ process SALMON_INDEX {
 
     script:
     def args = task.ext.args ?: ''
-    def get_decoy_ids = "grep '^>' $genome_fasta | cut -d ' ' -f 1 | cut -d \$'\\t' -f 1 > decoys.txt"
-    def gentrome      = "gentrome.fa"
-    if (genome_fasta.endsWith('.gz')) {
-        get_decoy_ids = "grep '^>' <(gunzip -c $genome_fasta) | cut -d ' ' -f 1 | cut -d \$'\\t' -f 1 > decoys.txt"
-        gentrome      = "gentrome.fa.gz"
-    }
     """
-    $get_decoy_ids
-    sed -i.bak -e 's/>//g' decoys.txt
-    cat $transcript_fasta $genome_fasta > $gentrome
-
-    salmon \\
-        index \\
+    salmon index \\
+        -t $transcript_fasta \\
+        -i salmon \\
         --threads $task.cpus \\
-        -t $gentrome \\
-        -d decoys.txt \\
         $args \\
-        -i salmon
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/salmon/quant/main.nf
+++ b/modules/nf-core/salmon/quant/main.nf
@@ -1,19 +1,16 @@
 process SALMON_QUANT {
     tag "$meta.id"
-    label "process_medium"
+    label "process_macbook"
 
     conda "bioconda::salmon=1.10.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/salmon:1.10.1--h7e5ed60_0' :
-        'biocontainers/salmon:1.10.1--h7e5ed60_0' }"
+        'quay.io/biocontainers/salmon:1.10.1--h7e5ed60_0' }"
 
     input:
     tuple val(meta), path(reads)
     path  index
-    path  gtf
     path  transcript_fasta
-    val   alignment_mode
-    val   lib_type
 
     output:
     tuple val(meta), path("${prefix}") , emit: results
@@ -27,40 +24,13 @@ process SALMON_QUANT {
     def args = task.ext.args   ?: ''
     prefix   = task.ext.prefix ?: "${meta.id}"
 
-    def reference   = "--index $index"
     def input_reads = meta.single_end ? "-r $reads" : "-1 ${reads[0]} -2 ${reads[1]}"
-    if (alignment_mode) {
-        reference   = "-t $transcript_fasta"
-        input_reads = "-a $reads"
-    }
 
-    def strandedness_opts = [
-        'A', 'U', 'SF', 'SR',
-        'IS', 'IU' , 'ISF', 'ISR',
-        'OS', 'OU' , 'OSF', 'OSR',
-        'MS', 'MU' , 'MSF', 'MSR'
-    ]
-    def strandedness =  'A'
-    if (lib_type) {
-        if (strandedness_opts.contains(lib_type)) {
-            strandedness = lib_type
-        } else {
-            log.info "[Salmon Quant] Invalid library type specified '--libType=${lib_type}', defaulting to auto-detection with '--libType=A'."
-        }
-    } else {
-        strandedness = meta.single_end ? 'U' : 'IU'
-        if (meta.strandedness == 'forward') {
-            strandedness = meta.single_end ? 'SF' : 'ISF'
-        } else if (meta.strandedness == 'reverse') {
-            strandedness = meta.single_end ? 'SR' : 'ISR'
-        }
-    }
     """
     salmon quant \\
-        --geneMap $gtf \\
         --threads $task.cpus \\
-        --libType=$strandedness \\
-        $reference \\
+        --libType A \\
+        --index $index \\
         $input_reads \\
         $args \\
         -o $prefix

--- a/modules/nf-core/salmon/quant/main.nf
+++ b/modules/nf-core/salmon/quant/main.nf
@@ -10,7 +10,6 @@ process SALMON_QUANT {
     input:
     tuple val(meta), path(reads)
     path  index
-    path  transcript_fasta
 
     output:
     tuple val(meta), path("${prefix}") , emit: results

--- a/nextflow.config
+++ b/nextflow.config
@@ -182,6 +182,7 @@ profiles {
     test_eggnog         { includeConfig 'conf/test_eggnog.config'       }
     test_eukulele       { includeConfig 'conf/test_eukulele.config'     }
     test_rnaspades      { includeConfig 'conf/test_rnaspades.config'    }
+    test_salmon         { includeConfig 'conf/test_salmon.config'       }
     test_trim_galore    { includeConfig 'conf/test_trim_galore.config'  }
     test_trinity        { includeConfig 'conf/test_trinity.config'      }
     test_dedupe         { includeConfig 'conf/test_dedupe.config'       }

--- a/salmon.nf
+++ b/salmon.nf
@@ -3,12 +3,17 @@
 // Arkea Bio Corp, May 2023
 
 include { SALMON_INDEX } from './modules/nf-core/salmon/index'
+include { SALMON_QUANT } from './modules/nf-core/salmon/quant'
 
-read_ch = Channel.fromPath(params.transcriptome, checkIfExists: true)
+txome = Channel.fromPath(params.transcriptome, checkIfExists: true)
+read_ch = Channel.fromFilePairs(params.pairedreads, checkIfExists: true)
+txome.view()
 read_ch.view()
 
 workflow SALMONY {
-    SALMON_INDEX(read_ch)
+    reads = read_ch.map  { [[id: 'test'], it[1]]}
+    salmon_ind = SALMON_INDEX(txome).index
+    SALMON_QUANT(reads, salmon_ind)
 }
 
 workflow  {

--- a/salmon.nf
+++ b/salmon.nf
@@ -1,0 +1,16 @@
+// Salmon indexing and quantification
+// Taylor Falk tfalk@arkeabio.com
+// Arkea Bio Corp, May 2023
+
+include { SALMON_INDEX } from './modules/nf-core/salmon/index'
+
+read_ch = Channel.fromPath(params.transcriptome, checkIfExists: true)
+read_ch.view()
+
+workflow SALMONY {
+    SALMON_INDEX(read_ch)
+}
+
+workflow  {
+    SALMONY()
+}


### PR DESCRIPTION
Blammo, salmon is happily counting the reads as they swim upstream. 

If you've been playing along you should have these files handy. Quant and Index were set up for aligned reads, so had to reconfigure them more significantly than normal.

```
nextflow run salmon.nf -profile docker,test_salmon
```
```
nextflow run salmon.nf -profile docker \
  --transcriptome "localdata/trinity_out.fa" \
  --pairedreads "localdata/reads/sub_SRR18336222_{1,2}.fastq"
```