### PR TITLE
Cb 204 configure multiple assemblies and downstream analysis

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -111,6 +111,12 @@ process {
         cpus = params.sandbox ? 16 : 128
         memory = params.sandbox ? 120.GB : 256.GB
     }
+
+    // Phase II tasks:
+    withName: 'ARKEA_SUPER_META_T:POST_ASSEMBLE_CLUSTER:EGGNOG_MAPPER' {
+        cpus = 16
+        memory = 120.GB
+    }
     withLabel:error_ignore {
         errorStrategy = 'ignore'
     }

--- a/conf/base.config
+++ b/conf/base.config
@@ -114,8 +114,8 @@ process {
 
     // Phase II tasks:
     withName: 'ARKEA_SUPER_META_T:POST_ASSEMBLE_CLUSTER:EGGNOG_MAPPER' {
-        cpus = params.sandbox ? 8 : 128
-        memory = params.sandbox ? 60.GB : 256.GB
+        cpus = params.sandbox ? 16 : 128
+        memory = params.sandbox ? 120.GB : 256.GB
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'

--- a/conf/base.config
+++ b/conf/base.config
@@ -114,8 +114,8 @@ process {
 
     // Phase II tasks:
     withName: 'ARKEA_SUPER_META_T:POST_ASSEMBLE_CLUSTER:EGGNOG_MAPPER' {
-        cpus = 4
-        memory = 30.GB
+        cpus = params.sandbox ? 8 : 128
+        memory = params.sandbox ? 60.GB : 256.GB
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'

--- a/conf/base.config
+++ b/conf/base.config
@@ -114,8 +114,8 @@ process {
 
     // Phase II tasks:
     withName: 'ARKEA_SUPER_META_T:POST_ASSEMBLE_CLUSTER:EGGNOG_MAPPER' {
-        cpus = 16
-        memory = 120.GB
+        cpus = 4
+        memory = 30.GB
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -296,6 +296,14 @@ process {
         ]
     }
 
+    withName: CAT_QUANTS {
+        publishDir = [
+            path: {"${params.outdir}/combined_assembly/salmon"},
+            mode: params.publish_dir_mode,
+            pattern: 'combined_quants.sf'
+        ]
+    }
+
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/pipeline_info" },

--- a/main_ii.nf
+++ b/main_ii.nf
@@ -1,0 +1,56 @@
+#!/usr/bin/env nextflow
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Arkea-Bio-Corp/metatdenovo 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Github        : https://github.com/Arkea-Bio-Corp/metatdenovo
+      forked from : https://github.com/nf-core/metatdenovo
+
+    Website: https://www.arkeabio.com/
+    Authors: Taylor Falk & Laura Holland
+
+    Runs the second half of the meta-transcriptome de novo pipeline with a collected 
+    group of assemblies.
+----------------------------------------------------------------------------------------
+*/
+
+nextflow.enable.dsl = 2
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    VALIDATE & PRINT PARAMETER SUMMARY
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+WorkflowMain.initialise(workflow, params, log)
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    NAMED WORKFLOW FOR PIPELINE
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+include { SUPERASSEMBLE } from './workflows/super_assemble'
+
+//
+// WORKFLOW: Run main Arkea-Bio-Corp/metatdenovo analysis pipeline
+//
+workflow ARKEA_SUPER_META_T {
+    POST_ASSEMBLE_CLUSTER ()
+}
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RUN ALL WORKFLOWS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+workflow {
+    ARKEA_SUPER_META_T ()
+}
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    THE END :^)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/

--- a/main_ii.nf
+++ b/main_ii.nf
@@ -30,7 +30,7 @@ WorkflowMain.initialise(workflow, params, log)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { SUPERASSEMBLE } from './workflows/super_assemble'
+include { POST_ASSEMBLE_CLUSTER } from './workflows/super_assemble'
 
 //
 // WORKFLOW: Run main Arkea-Bio-Corp/metatdenovo analysis pipeline
@@ -54,3 +54,4 @@ workflow {
     THE END :^)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
+ 

--- a/modules/local/cat/cat_quants.nf
+++ b/modules/local/cat/cat_quants.nf
@@ -14,7 +14,7 @@ process CAT_QUANTS {
         quants.collect{ it.toString() } : 
         [quants.toString()]
     """
-    # head -1 $quants > combined_quants.sf
+    head -q -n 1 $quants | tail -1 > combined_quants.sf
     grep -vh "^Name" ${qlist.join(' ')} >> combined_quants.sf
     """
 }

--- a/modules/local/cat/cat_quants.nf
+++ b/modules/local/cat/cat_quants.nf
@@ -1,0 +1,20 @@
+process CAT_QUANTS {
+    label 'process_low'
+
+    container "quay.io/biocontainers/grep:3.4--hf43ccf4_4"
+
+    input:
+    path(quants, stageAs: "?/*")
+
+    output:
+    path("combined_quants.sf")      , emit: combined
+
+    script:
+    def qlist = quants instanceof List ? 
+        quants.collect{ it.toString() } : 
+        [quants.toString()]
+    """
+    # head -1 $quants > combined_quants.sf
+    grep -vh "^Name" ${qlist.join(' ')} >> combined_quants.sf
+    """
+}

--- a/modules/nf-core/cat/cat/main.nf
+++ b/modules/nf-core/cat/cat/main.nf
@@ -1,6 +1,5 @@
 process CAT_CAT {
     tag "$meta.id"
-    label 'process_low'
 
     conda "conda-forge::pigz=2.3.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/salmon/quant/main.nf
+++ b/modules/nf-core/salmon/quant/main.nf
@@ -13,6 +13,7 @@ process SALMON_QUANT {
     output:
     tuple val(meta), path("${prefix}") , emit: results
     tuple val(meta), path("*info.json"), emit: json_info, optional: true
+    path  "quant.sf"                   , emit: quants
     path  "versions.yml"               , emit: versions
 
     when:

--- a/modules/nf-core/salmon/quant/main.nf
+++ b/modules/nf-core/salmon/quant/main.nf
@@ -13,7 +13,7 @@ process SALMON_QUANT {
     output:
     tuple val(meta), path("${prefix}") , emit: results
     tuple val(meta), path("*info.json"), emit: json_info, optional: true
-    path  "quant.sf"                   , emit: quants
+    path  "*/quant.sf"                   , emit: quants
     path  "versions.yml"               , emit: versions
 
     when:

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -260,7 +260,7 @@ workflow METATDENOVO {
     // Functional annotation with eggnog-mapper
     // 
     eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
-    eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
+    eggnog_ch = Channel.value(file(params.eggnogdir, checkIfExists: true))
     EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
     ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
 

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -118,7 +118,6 @@ workflow POST_ASSEMBLE_CLUSTER {
 
     // Functional annotation with eggnog-mapper
     eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
-    // eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
     eggnog_ch = Channel.value(file(params.eggnogdir, checkIfExists: true))
     EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
     ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -1,0 +1,84 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    VALIDATE INPUTS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
+
+// Validate input parameters
+WorkflowMetatdenovo.initialise(params, log)
+
+// Check input path parameters to see if they exist
+def checkPathParamList = [ params.input, params.multiqc_config ]
+for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
+
+// Check mandatory parameters
+if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
+
+// set an empty multiqc channel
+ch_multiqc_files = Channel.empty()
+
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    CONFIG FILES
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+ch_multiqc_config          = Channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
+ch_multiqc_custom_config   = params.multiqc_config ? Channel.fromPath( params.multiqc_config, checkIfExists: true ) : Channel.empty()
+ch_multiqc_logo            = params.multiqc_logo   ? Channel.fromPath( params.multiqc_logo, checkIfExists: true ) : Channel.empty()
+ch_multiqc_custom_methods_description = params.multiqc_methods_description ? file(params.multiqc_methods_description, checkIfExists: true) : file("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    IMPORT LOCAL MODULES/SUBWORKFLOWS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+//
+// MODULE: local
+//
+include { HMMER_HMMSCAN                    } from '../modules/local/hmmscan/main'
+include { EGGNOG_MAPPER                    } from '../modules/local/eggnog/mapper'
+
+//
+// SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
+//
+
+//
+// SUBWORKFLOW: Consisting of local modules
+//
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    IMPORT NF-CORE MODULES/SUBWORKFLOWS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+//
+// MODULE: Installed directly from nf-core/modules (mostly)
+//
+
+include { MULTIQC                      } from '../modules/nf-core/multiqc/'
+include { CUSTOM_DUMPSOFTWAREVERSIONS  } from '../modules/nf-core/custom/dumpsoftwareversions/'
+include { CDHIT_CDHIT                  } from '../modules/nf-core/cdhit/'
+include { KRAKEN2_KRAKEN2 as KRKN_ARCH } from '../modules/nf-core/kraken2/'
+include { SALMON_INDEX                 } from '../modules/nf-core/salmon/index/'
+include { SALMON_QUANT                 } from '../modules/nf-core/salmon/quant/'
+include { TRANSDECODER_LONGORF         } from '../modules/nf-core/transdecoder/longorf/'
+include { TRANSDECODER_PREDICT         } from '../modules/nf-core/transdecoder/predict/'
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    RUN MAIN WORKFLOW
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+def multiqc_report = []
+
+
+workflow POST_ASSEMBLE_CLUSTER {
+
+}

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -94,7 +94,7 @@ workflow POST_ASSEMBLE_CLUSTER {
     Channel.fromPath(ch_input)
         .splitCsv(header: ['sample', 'assembly', 'reads'], skip: 1 )
         .collect(row -> "${row.assembly}")
-        .map { [[id: "sample", single_end: true], it] }
+        .map { [[id: "combined_assembly", single_end: true], it] }
         .set { assembly_list }
 
     Channel.fromPath(ch_input)

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -95,14 +95,12 @@ workflow POST_ASSEMBLE_CLUSTER {
         .splitCsv(header: ['sample', 'assembly', 'reads'], skip: 1 )
         .collect(row -> "${row.assembly}")
         .map{ [[id: "sample", single_end: true], it] }
-        .view()
         .set { assembly_list }
 
     Channel.fromPath(ch_input)
         .splitCsv(header: ['sample', 'assembly', 'reads'], skip: 1 )
         .collect(row -> "${row.reads}")
         .map{ [[id: "sample", single_end: true], it] }
-        .view()
         .set { reads_list }
 
     // combine gzipped fastq reads with CAT 🐈‍⬛

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -72,7 +72,7 @@ include { SALMON_INDEX                 } from '../modules/nf-core/salmon/index/'
 include { SALMON_QUANT                 } from '../modules/nf-core/salmon/quant/'
 include { TRANSDECODER_LONGORF         } from '../modules/nf-core/transdecoder/longorf/'
 include { TRANSDECODER_PREDICT         } from '../modules/nf-core/transdecoder/predict/'
-
+include { CAT_QUANTS                   } from '../modules/local/cat/cat_quants'
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     RUN MAIN WORKFLOW
@@ -123,11 +123,15 @@ workflow POST_ASSEMBLE_CLUSTER {
     SALMON_QUANT(reads_list, salmon_ind)   
     ch_versions = ch_versions.mix(SALMON_QUANT.out.versions)
 
+
+    CAT_QUANTS(SALMON_QUANT.out.quants.collect())
+    CAT_QUANTS.out.combined.view()
+
     // Functional annotation with eggnog-mapper
-    eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
-    eggnog_ch = Channel.value(file(params.eggnogdir, checkIfExists: true))
-    EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
-    ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
+    // eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
+    // eggnog_ch = Channel.value(file(params.eggnogdir, checkIfExists: true))
+    // EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
+    // ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
 
     // Functional annotation with hmmscan
     hmmerdir   = Channel.fromPath(params.hmmdir, checkIfExists: true)

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -128,10 +128,10 @@ workflow POST_ASSEMBLE_CLUSTER {
     CAT_QUANTS.out.combined.view()
 
     // Functional annotation with eggnog-mapper
-    // eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
-    // eggnog_ch = Channel.value(file(params.eggnogdir, checkIfExists: true))
-    // EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
-    // ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
+    eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
+    eggnog_ch = Channel.value(file(params.eggnogdir, checkIfExists: true))
+    EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
+    ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
 
     // Functional annotation with hmmscan
     hmmerdir   = Channel.fromPath(params.hmmdir, checkIfExists: true)

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -104,5 +104,34 @@ workflow POST_ASSEMBLE_CLUSTER {
     CDHIT_CDHIT(CAT_CAT.out.file_out)
     ch_versions = ch_versions.mix(CDHIT_CDHIT.out.versions) 
 
-    
+    // ORF prediction
+    tdecoder_folder = TRANSDECODER_LONGORF(CDHIT_CDHIT.out.fasta).folder
+    ch_versions = ch_versions.mix(TRANSDECODER_LONGORF.out.versions)
+    TRANSDECODER_PREDICT(CDHIT_CDHIT.out.fasta, tdecoder_folder)
+    ch_versions = ch_versions.mix(TRANSDECODER_PREDICT.out.versions)
+
+    // Quantification w/ salmon
+    // salmon_ind = SALMON_INDEX(TRINITY.out.transcript_fasta).index
+    // ch_versions = ch_versions.mix(SALMON_INDEX.out.versions)
+    // SALMON_QUANT(CAT_FASTQ.out.reads, salmon_ind)   
+    // ch_versions = ch_versions.mix(SALMON_QUANT.out.versions)
+
+    // Functional annotation with eggnog-mapper
+    eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
+    eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
+    EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
+    ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
+
+    // Functional annotation with hmmscan
+    hmmerdir   = Channel.fromPath(params.hmmdir, checkIfExists: true)
+    hmmerfile  = Channel.value(params.hmmerfile)
+    HMMER_HMMSCAN(TRANSDECODER_PREDICT.out.pep, hmmerdir, hmmerfile)
+    ch_versions = ch_versions.mix(HMMER_HMMSCAN.out.versions)
+ 
+    // Kraken2 taxonomical annotation of contigs 
+    // adjust metamap to switch to single end
+    trans_cds = TRANSDECODER_PREDICT.out.cds.map{ [[id: it[0].id, single_end: true], it[1]]} 
+    k2_arch_db = Channel.fromPath(params.archaea_db, checkIfExists: true)
+    KRKN_ARCH(trans_cds, k2_arch_db, true, true)
+    ch_versions = ch_versions.mix(KRKN_ARCH.out.versions)
 }

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -62,7 +62,8 @@ include { EGGNOG_MAPPER                    } from '../modules/local/eggnog/mappe
 //
 
 include { CAT_CAT                      } from '../modules/nf-core/cat/cat/'
-include { CAT_FASTQ 	          	        } from '../modules/nf-core/cat/fastq/'
+include { CAT_CAT as CAT_QUANT         } from '../modules/nf-core/cat/cat/'
+include { CAT_FASTQ 	          	   } from '../modules/nf-core/cat/fastq/'
 include { MULTIQC                      } from '../modules/nf-core/multiqc/'
 include { CUSTOM_DUMPSOFTWAREVERSIONS  } from '../modules/nf-core/custom/dumpsoftwareversions/'
 include { CDHIT_CDHIT                  } from '../modules/nf-core/cdhit/'

--- a/workflows/super_assemble.nf
+++ b/workflows/super_assemble.nf
@@ -118,7 +118,8 @@ workflow POST_ASSEMBLE_CLUSTER {
 
     // Functional annotation with eggnog-mapper
     eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
-    eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
+    // eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
+    eggnog_ch = Channel.value(file(params.eggnogdir, checkIfExists: true))
     EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
     ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the ArkeaBio Code Review Policy: https://docs.google.com/document/d/1yX6rkFrQQhdozEB8OBE9jWsQZgDMw3KS0DLd7MWPEAo/edit#heading=h.tgvpr2mcrxkb
     - 👷‍♀️ Create small PRs. 
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 📗 Analysis
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
Remember when we made pull requests? This is what I call "phase 2" of the pipeline. After each sample or groups of samples has been processed, their assemblies and reads should be combined, respectively, and then put through annotation and counting steps.

This branch, started with `main_ii.nf`, takes in a CSV of sample name, assembly path, and read path (before deduplication). It then concatenates assemblies and reads together, and runs salmon, cd-hit, transdecoder, kraken2, eggnog, and hmmersearch on the results. This will give us our wonderful counts table so we can see what our favorite little bugs are up to.

## Jira Task
<!-- 
Link to Jira task.
-->
[CB-204](https://arkeabio.atlassian.net/browse/CB-204) Configure multiple assemblies and downstream analysis

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📕 notebook(s)
- [x] 🙅 no documentation needed

## Code Quality
- [x] 🎯 The code is properly formatted and adheres to the project's style guide
- [x] 🎯 The code runs without any errors or exceptions

## Compute Environment
<!--
Where does this code need to run? Locally? EC2 instance? AWS Batch? Somewhere else?
-->
I have only tested this on sandbox so far, but it should be appropriate for Tower as well.

## Testing
<!-- 
Specify how to test the code and where test files are located.
Required for tools/pipelines. 
-->
I don't foresee testing this on Tower any time soon, as all the data is made up already, but if you'd like to run it on Sandbox the data is publicly available. Just clone this branch and run:
```
 nextflow run main_ii.nf \
  -profile docker \
  --input /data/meta-t/phase2/assemblies/assemblies.csv \
  --outdir results_six \
  --eggnogdir /data/meta-t/eggnog_db/ \
  --hmmdir /data/meta-t/hmmer_pfam/ \
  --hmmerfile "Pfam-A.hmm" \
  --archaea_db /data/meta-t/kraken2db/archaea_db/ \
  --sandbox
 ```

The `--sandbox` flag is a new feature I added which just tells Nextflow not to ask for crazy, AWS-level resources and immediately tank my sandbox jobs. Run takes a couple minutes, minus eggnog mapper which takes 1.5 million years.

<img src="https://media1.giphy.com/media/xT5LMNFIVyla9VB0Mo/giphy.gif"/>