### PR TITLE
Cb 224 remove task index from filter tasks to improve resume

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: Deploy to ECR
+
+on:
+  push:
+    branches:    
+      - '*'         # matches every branch that doesn't contain a '/'
+      - '*/*'       # matches every branch containing a single '/'
+      - '**'        # matches every branch
+      - '!master'   # excludes master
+
+jobs:  
+  build:
+    
+    name: Build Image
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v3
+    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+        
+    - name: Login to Amazon ECR Public
+      id: login-ecr-public
+      uses: aws-actions/amazon-ecr-login@v1
+      with:
+        registry-type: public
+
+    - name: Build, tag, and push docker image to Amazon ECR Public
+      env:
+        REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+        REGISTRY_ALIAS: r8r1f0u4
+        REPOSITORY: plotting
+        IMAGE_TAG: latest
+        REPO_IMAGE_PATH: containers/plotting
+      run: |
+        echo $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+        docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG -f $REPO_IMAGE_PATH .
+        docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG

--- a/bin/parse_all_counts.R
+++ b/bin/parse_all_counts.R
@@ -1,5 +1,6 @@
 #!/usr/bin/env Rscript
 suppressMessages(library(tidyverse))
+
 args <- commandArgs(trailingOnly = TRUE)
 
 counts_input <- as_tibble(read.csv(args[1],
@@ -31,7 +32,8 @@ b <- ggplot(counts_table, aes(x = Tool, y = Reads, fill = Reads)) +
     legend.position = "none"
   )
 
-l <- plotly::ggplotly(b)
+library(highcharter)
+hchart(counts_table, "column", hcaes(x = Tool, y = Reads)) -> l
 
 htmlwidgets::saveWidget(l, "All_counts_plot_mqc.html")
 

--- a/bin/parse_all_counts.R
+++ b/bin/parse_all_counts.R
@@ -18,7 +18,7 @@ counts_input %>%
   summarise(across(everything(), sum)) %>%
   within(Tool <- factor(Tool, levels = order_pipeline)) -> counts_table
 
-ggplot(counts_table, aes(x = Tool, y = Reads, fill = Reads)) +
+b <- ggplot(counts_table, aes(x = Tool, y = Reads, fill = Reads)) +
   geom_bar(stat = "identity") +
   scale_fill_gradient(low = "darkgreen", high = "red") +
   theme_minimal() +
@@ -30,6 +30,10 @@ ggplot(counts_table, aes(x = Tool, y = Reads, fill = Reads)) +
     axis.text.x = element_text(angle = 35, vjust = 0.75),
     legend.position = "none"
   )
+
+l <- plotly::ggplotly(b)
+
+htmlwidgets::saveWidget(l, "All_counts_plot_mqc.html")
 
 ggsave(
   filename = "All_counts_plot_mqc.png", device = "png",

--- a/bin/parse_all_counts.R
+++ b/bin/parse_all_counts.R
@@ -1,40 +1,37 @@
 #!/usr/bin/env Rscript
 suppressMessages(library(tidyverse))
-library(yaml)
-
 args <- commandArgs(trailingOnly = TRUE)
-counts_yaml <- read_yaml(args[1])
 
-order_pipeline <- c("TRIMMOMATIC", "BOWTIE2_ALIGN", "SORTMERNA", "KRKN_NO_ARCH", 
-                    "CAT_FASTQ", "BBMAP_MERGE", "BBMAP_DEDUPE")
+counts_input <- as_tibble(read.csv(args[1],
+  header = F,
+  col.names = c("Tool", "Reads")
+))
 
-sum_by_name <- function(count_name, yaml) {
-  return(Reduce("+", yaml[grep(count_name, names(yaml))]))
-}
+order_pipeline <- c(
+  "TRIMMOMATIC", "BOWTIE2_ALIGN", "SORTMERNA", "KRKN_NO_ARCH",
+  "CAT_FASTQ", "BBMAP_MERGE", "BBMAP_DEDUPE"
+)
 
-res <- data.frame(tool   = order_pipeline,
-                  counts = c(sum_by_name("TRIMMOMATIC", counts_yaml),
-                             sum_by_name("BOWTIE", counts_yaml),
-                             sum_by_name("SORTMERNA", counts_yaml)/2,
-                             sum_by_name("KRKN_NO_ARCH", counts_yaml),
-                             counts_yaml$`NFCORE_METATDENOVO:METATDENOVO:CAT_FASTQ`,
-                             counts_yaml$`NFCORE_METATDENOVO:METATDENOVO:BBMAP_MERGE`,
-                             counts_yaml$`NFCORE_METATDENOVO:METATDENOVO:BBMAP_DEDUPE`),
-                  effect = c("Trim", "Filter", "Filter", "Filter", "Combine", "Merge", 
-                             "Filter"))
-res$tool <- factor(res$tool, levels=order_pipeline)
+counts_input %>%
+  separate(Tool, into = c(NA, NA, "Tool"), sep = ":", remove = FALSE) %>%
+  group_by(Tool) %>%
+  summarise(across(everything(), sum)) %>%
+  within(Tool <- factor(Tool, levels = order_pipeline)) -> counts_table
 
-ggplot(res, aes(x=tool, y=counts, fill = effect)) +
-  geom_bar(stat="identity") +
+ggplot(counts_table, aes(x = Tool, y = Reads, fill = Reads)) +
+  geom_bar(stat = "identity") +
+  scale_fill_gradient(low = "darkgreen", high = "red") +
   theme_minimal() +
   ggtitle("Total Counts After Each Step, before Assembly") +
   xlab("Tool") +
   ylab("Number of reads") +
   scale_y_continuous(labels = scales::unit_format(unit = "M", scale = 1e-6)) +
-  scale_fill_manual("Effect", values = c("#E03616", "#5C946E", "#F45B69", "#645E9D")) +
-  theme(axis.text.x = element_text(angle = 35, vjust = 0.75),
-        legend.box.background = element_rect(colour = "black"),
-        legend.position = "top")
+  theme(
+    axis.text.x = element_text(angle = 35, vjust = 0.75),
+    legend.position = "none"
+  )
 
-ggsave(filename = "All_counts_plot_mqc.png", device = "png",
-       width = 8, height = 4, units = "in", bg = "#FFFFFF")
+ggsave(
+  filename = "All_counts_plot_mqc.png", device = "png",
+  width = 8, height = 4, units = "in", bg = "#FFFFFF"
+)

--- a/bin/parse_all_counts.R
+++ b/bin/parse_all_counts.R
@@ -1,6 +1,5 @@
 #!/usr/bin/env Rscript
 suppressMessages(library(tidyverse))
-
 args <- commandArgs(trailingOnly = TRUE)
 
 counts_input <- as_tibble(read.csv(args[1],
@@ -32,8 +31,7 @@ b <- ggplot(counts_table, aes(x = Tool, y = Reads, fill = Reads)) +
     legend.position = "none"
   )
 
-library(highcharter)
-hchart(counts_table, "column", hcaes(x = Tool, y = Reads)) -> l
+l <- plotly::ggplotly(b)
 
 htmlwidgets::saveWidget(l, "All_counts_plot_mqc.html")
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -368,7 +368,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/pipeline_info" },
             mode: params.publish_dir_mode,
-            pattern: '*.txt'
+            pattern: '*.csv'
         ]
     }
 

--- a/containers/plotting
+++ b/containers/plotting
@@ -1,0 +1,3 @@
+FROM rocker/verse
+
+RUN Rscript -e 'install.packages(c("plotly", "htmlwidgets"))'

--- a/containers/plotting
+++ b/containers/plotting
@@ -1,3 +1,3 @@
 FROM rocker/verse
 
-RUN Rscript -e 'install.packages(c("plotly", "htmlwidgets"))'
+RUN Rscript -e 'install.packages(c("plotly", "htmlwidgets", "highcharter"))'

--- a/modules/local/counts_plot.nf
+++ b/modules/local/counts_plot.nf
@@ -8,6 +8,7 @@ process COUNTS_PLOT {
 
     output:
     path("*.png")                               , emit: counts_png
+    path("*.html")                              , emit: counts_html
     path "versions.yml"                         , emit: versions
 
     when:

--- a/modules/local/counts_plot.nf
+++ b/modules/local/counts_plot.nf
@@ -1,7 +1,7 @@
 process COUNTS_PLOT {
     tag "$meta.id"
 
-    container "rocker/verse"
+    container "public.ecr.aws/arkeabio/plotting:latest"
 
     input:
     tuple val(meta), path(counts_txt)

--- a/modules/nf-core/bbmap/dedupe/main.nf
+++ b/modules/nf-core/bbmap/dedupe/main.nf
@@ -14,7 +14,7 @@ process BBMAP_DEDUPE {
     tuple val(meta), path('*.log')     , emit: log
     tuple val(meta), val("null")       , emit: meta // passing meta tag only to others
     path "versions.yml"                , emit: versions
-    path "counts.txt"                  , emit: readcounts
+    path "counts.csv"                  , emit: readcounts
 
 
     when:
@@ -38,9 +38,8 @@ process BBMAP_DEDUPE {
     "${task.process}":
         bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
     END_VERSIONS
-    cat <<-END_COUNTS > counts.txt
-    "${task.process}":
-        \$(zcat ${prefix}.fastq.gz | grep -c "@" )
+    cat <<-END_COUNTS > counts.csv
+    "${task.process}",\$(zcat ${prefix}.fastq.gz | grep -c "@" )
     END_COUNTS
     """
 }

--- a/modules/nf-core/bbmap/merge/main.nf
+++ b/modules/nf-core/bbmap/merge/main.nf
@@ -15,7 +15,7 @@ process BBMAP_MERGE {
     tuple val(meta), path('*.log')            , emit: log
     tuple val(meta), path('*.ihist.txt')      , emit: ihist
     path "versions.yml"                       , emit: versions
-    path "counts.txt"                         , emit: readcounts
+    path "counts.csv"                         , emit: readcounts
 
     when:
     task.ext.when == null || task.ext.when
@@ -41,9 +41,8 @@ process BBMAP_MERGE {
     "${task.process}":
         bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
     END_VERSIONS
-    cat <<-END_COUNTS > counts.txt
-    "${task.process}":
-        \$(zcat ${prefix}.merged.fq.gz | grep -c "@" )
+    cat <<-END_COUNTS > counts.csv
+    "${task.process}", \$(zcat ${prefix}.merged.fq.gz | grep -c "@" )
     END_COUNTS
     """
 }

--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -17,7 +17,7 @@ process BOWTIE2_ALIGN {
     tuple val(meta), path("*.log")    , emit: log
     tuple val(meta), path("*fastq.gz"), emit: fastq, optional:false
     path "versions.yml"               , emit: versions
-    path "counts.txt"                 , emit: readcounts
+    path "counts.csv"                 , emit: readcounts
     tuple val(meta), val("null")      , emit: meta // passing meta tag only 
     path('*.log')                     , emit: collect_log 
 
@@ -69,9 +69,8 @@ process BOWTIE2_ALIGN {
         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
         pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
     END_VERSIONS
-    cat <<-END_COUNTS > counts.txt
-    "${task.process}_${task.index}":
-        \$(zcat ${prefix}.unmapped_*.fastq.gz | grep -c "@" | awk '{print \$1/2}')
+    cat <<-END_COUNTS > counts.csv
+    "${task.process}", \$(zcat ${prefix}.unmapped_*.fastq.gz | grep -c "@" | awk '{print \$1/2}')
     END_COUNTS
     """
 }

--- a/modules/nf-core/cat/cat/main.nf
+++ b/modules/nf-core/cat/cat/main.nf
@@ -12,7 +12,7 @@ process CAT_CAT {
     output:
     tuple val(meta), path("${prefix}"), emit: file_out
     path "versions.yml"               , emit: versions
-    path "counts.txt"                 , emit: readcounts
+    path "counts.csv"                 , emit: readcounts
 
     when:
     task.ext.when == null || task.ext.when
@@ -46,9 +46,8 @@ process CAT_CAT {
     "${task.process}":
         pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
     END_VERSIONS
-    cat <<-END_COUNTS > counts.txt
-    "${task.process}":
-        \$(zcat ${prefix} | grep -c "@" )
+    cat <<-END_COUNTS > counts.csv
+    "${task.process}", \$(zcat ${prefix} | grep -c "@" )
     END_COUNTS
     """
 }

--- a/modules/nf-core/cat/fastq/main.nf
+++ b/modules/nf-core/cat/fastq/main.nf
@@ -13,7 +13,7 @@ process CAT_FASTQ {
     output:
     tuple val(meta), path("*.merged.fastq.gz"), emit: reads
     path "versions.yml"                       , emit: versions
-    path "counts.txt"                         , emit: readcounts
+    path "counts.csv"                         , emit: readcounts
 
     when:
     task.ext.when == null || task.ext.when
@@ -31,9 +31,8 @@ process CAT_FASTQ {
             "${task.process}":
                 cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
             END_VERSIONS
-            cat <<-END_COUNTS > counts.txt
-            "${task.process}":
-                \$(zcat *.merged.fastq.gz | grep -c "@" )
+            cat <<-END_COUNTS > counts.csv
+            "${task.process}", \$(zcat *.merged.fastq.gz | grep -c "@" )
             END_COUNTS
             """
         }
@@ -50,9 +49,8 @@ process CAT_FASTQ {
             "${task.process}":
                 cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
             END_VERSIONS
-            cat <<-END_COUNTS > counts.txt
-            "${task.process}":
-                \$(zcat *.merged.fastq.gz | grep -c "@" )
+            cat <<-END_COUNTS > counts.csv
+            "${task.process}", \$(zcat *.merged.fastq.gz | grep -c "@" )
             END_COUNTS
             """
         }

--- a/modules/nf-core/custom/dumpcounts/main.nf
+++ b/modules/nf-core/custom/dumpcounts/main.nf
@@ -9,13 +9,13 @@ process CUSTOM_DUMPCOUNTS {
     tuple val(meta), val("null")
 
     output:
-    tuple val(meta), path("pipeline_counts.txt"), emit: readcounts
+    tuple val(meta), path("pipeline_counts.csv"), emit: readcounts
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     """
-    cat collated_counts.txt > pipeline_counts.txt
+    cat collated_counts.csv > pipeline_counts.csv
     """
 }

--- a/modules/nf-core/kraken2/main.nf
+++ b/modules/nf-core/kraken2/main.nf
@@ -20,7 +20,7 @@ process KRAKEN2_KRAKEN2 {
     tuple val(meta), val("null")                 , emit: meta // passing meta tag only to others
     path('*report.txt')                          , emit: collect_log // only report to collect
     path "versions.yml"                          , emit: versions
-    path "counts.txt"                            , emit: readcounts
+    path "counts.csv"                            , emit: readcounts
 
     when:
     task.ext.when == null || task.ext.when
@@ -57,9 +57,8 @@ process KRAKEN2_KRAKEN2 {
         kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
         pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
     END_VERSIONS
-    cat <<-END_COUNTS > counts.txt
-    "${task.process}_${task.index}":
-        \$(zcat *unclassified* | grep -c "@" )
+    cat <<-END_COUNTS > counts.csv
+    "${task.process}", \$(zcat *unclassified* | grep -c "@" )
     END_COUNTS
     """
 }

--- a/modules/nf-core/sortmerna/main.nf
+++ b/modules/nf-core/sortmerna/main.nf
@@ -17,7 +17,7 @@ process SORTMERNA {
     tuple val(meta), val("null")       , emit: meta // passing meta tag only to others
     path "*.log"                       , emit: collect_log
     path  "versions.yml"               , emit: versions
-    path  "counts.txt"                 , emit: readcounts
+    path  "counts.csv"                 , emit: readcounts
 
     when:
     task.ext.when == null || task.ext.when
@@ -49,9 +49,8 @@ process SORTMERNA {
         "${task.process}":
             sortmerna: \$(echo \$(sortmerna --version 2>&1) | sed 's/^.*SortMeRNA version //; s/ Build Date.*\$//')
         END_VERSIONS
-        cat <<-END_COUNTS > counts.txt
-        "${task.process}_${task.index}":
-            \$(zcat *non_rRNA.fastq.gz | grep -c "@" )
+        cat <<-END_COUNTS > counts.csv
+        "${task.process}", \$(zcat *non_rRNA.fastq.gz | grep -c "@" )
         END_COUNTS
         """
     } else {
@@ -78,9 +77,8 @@ process SORTMERNA {
         "${task.process}":
             sortmerna: \$(echo \$(sortmerna --version 2>&1) | sed 's/^.*SortMeRNA version //; s/ Build Date.*\$//')
         END_VERSIONS
-        cat <<-END_COUNTS > counts.txt
-        "${task.process}_${task.index}":
-            \$(zcat *non_rRNA.fastq.gz | grep -c "@" )
+        cat <<-END_COUNTS > counts.csv
+        "${task.process}", \$(zcat *non_rRNA.fastq.gz | grep -c "@" )
         END_COUNTS
         """
     }

--- a/modules/nf-core/transdecoder/longorf/main.nf
+++ b/modules/nf-core/transdecoder/longorf/main.nf
@@ -1,5 +1,6 @@
 process TRANSDECODER_LONGORF {
     tag "$meta.id"
+    cache false
 
     conda "bioconda::transdecoder=5.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/transdecoder/predict/main.nf
+++ b/modules/nf-core/transdecoder/predict/main.nf
@@ -1,5 +1,6 @@
 process TRANSDECODER_PREDICT {
     tag "$meta.id"
+    cache false
 
     conda "bioconda::transdecoder=5.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/trimmomatic/main.nf
+++ b/modules/nf-core/trimmomatic/main.nf
@@ -18,7 +18,7 @@ process TRIMMOMATIC {
     tuple val(meta), val("null")       , emit: meta // passing meta tag only to others
     path "*.log"                       , emit: collect_log
     path  "versions.yml"               , emit: versions
-    path  "counts.txt"                 , emit: readcounts
+    path  "counts.csv"                 , emit: readcounts
 
     when:
     task.ext.when == null || task.ext.when
@@ -47,9 +47,8 @@ process TRIMMOMATIC {
     "${task.process}":
         trimmomatic: \$(trimmomatic -version)
     END_VERSIONS
-    cat <<-END_COUNTS > counts.txt
-    "${task.process}_${task.index}":
-        \$(zcat ${prefix}.paired.trim_*.fastq.gz | grep -c "@" | awk '{print \$1/2}')
+    cat <<-END_COUNTS > counts.csv
+    "${task.process}", \$(zcat ${prefix}.paired.trim_*.fastq.gz | grep -c "@" | awk '{print \$1/2}')
     END_COUNTS
     """
 }

--- a/tower.yml
+++ b/tower.yml
@@ -1,7 +1,7 @@
 reports:
   "**/multiqc_report.html":
     display: MultiQC Report
-  "**/pipeline_counts.txt":
+  "**/pipeline_counts.csv":
     display: Count Details
   "**/Kraken2_no_archaea_logs.txt":
     display: Kraken2 No Archaea Combined Parallel Report

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -230,7 +230,7 @@ workflow METATDENOVO {
     BBMAP_DEDUPE(merged_reads)
     ch_versions = ch_versions.mix(BBMAP_DEDUPE.out.versions)
     ch_read_counts = ch_read_counts.mix(BBMAP_DEDUPE.out.readcounts)
-    CUSTOM_DUMPCOUNTS(ch_read_counts.collectFile(name: 'collated_counts.txt'), 
+    CUSTOM_DUMPCOUNTS(ch_read_counts.collectFile(name: 'collated_counts.csv'), 
                                                  BBMAP_DEDUPE.out.meta)
 
     // 
@@ -328,8 +328,9 @@ workflow METATDENOVO {
     workflow_summary    = WorkflowMetatdenovo.paramsSummaryMultiqc(workflow, summary_params)
     ch_workflow_summary = Channel.value(workflow_summary)
 
-    COUNTS_PLOT(CUSTOM_DUMPCOUNTS.out.readcounts)
-    ch_versions = ch_versions.mix(COUNTS_PLOT.out.versions)
+    // TODO: don't forget me........
+    // COUNTS_PLOT(CUSTOM_DUMPCOUNTS.out.readcounts)
+    // ch_versions = ch_versions.mix(COUNTS_PLOT.out.versions)
 
     methods_description    = WorkflowMetatdenovo.methodsDescriptionText(workflow, ch_multiqc_custom_methods_description)
     ch_methods_description = Channel.value(methods_description)
@@ -337,7 +338,7 @@ workflow METATDENOVO {
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(PRE_TRIM_FQC.out.zip.collect{it[1]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(POST_MERGE_FQC.out.zip.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_png.ifEmpty([]))
+    // ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_png.ifEmpty([]))
 
 
     MULTIQC (

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -293,10 +293,10 @@ workflow METATDENOVO {
         // 
         // Functional annotation with eggnog-mapper
         // 
-        // eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
-        // eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
-        // EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
-        // ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
+        eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
+        eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
+        EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
+        ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
 
         // 
         // Functional annotation with hmmscan

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -293,10 +293,10 @@ workflow METATDENOVO {
         // 
         // Functional annotation with eggnog-mapper
         // 
-        eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
-        eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
-        EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
-        ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
+        // eggdbchoice = ["diamond", "mmseqs", "hmmer", "novel_fams"]
+        // eggnog_ch = Channel.fromPath(params.eggnogdir, checkIfExists: true)
+        // EGGNOG_MAPPER(TRANSDECODER_PREDICT.out.pep, eggnog_ch, eggdbchoice)
+        // ch_versions = ch_versions.mix(EGGNOG_MAPPER.out.versions)
 
         // 
         // Functional annotation with hmmscan
@@ -339,7 +339,7 @@ workflow METATDENOVO {
     ch_multiqc_files = ch_multiqc_files.mix(POST_MERGE_FQC.out.zip.collect{it[1]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_png.ifEmpty([]))
     // Plotly output is buggy, skip for now:
-    // ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_html.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_html.ifEmpty([]))
 
 
     MULTIQC (

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -328,9 +328,8 @@ workflow METATDENOVO {
     workflow_summary    = WorkflowMetatdenovo.paramsSummaryMultiqc(workflow, summary_params)
     ch_workflow_summary = Channel.value(workflow_summary)
 
-    // TODO: don't forget me........
-    // COUNTS_PLOT(CUSTOM_DUMPCOUNTS.out.readcounts)
-    // ch_versions = ch_versions.mix(COUNTS_PLOT.out.versions)
+    COUNTS_PLOT(CUSTOM_DUMPCOUNTS.out.readcounts)
+    ch_versions = ch_versions.mix(COUNTS_PLOT.out.versions)
 
     methods_description    = WorkflowMetatdenovo.methodsDescriptionText(workflow, ch_multiqc_custom_methods_description)
     ch_methods_description = Channel.value(methods_description)
@@ -338,7 +337,8 @@ workflow METATDENOVO {
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(PRE_TRIM_FQC.out.zip.collect{it[1]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(POST_MERGE_FQC.out.zip.collect{it[1]}.ifEmpty([]))
-    // ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_png.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_png.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_html.ifEmpty([]))
 
 
     MULTIQC (

--- a/workflows/metatdenovo.nf
+++ b/workflows/metatdenovo.nf
@@ -338,7 +338,8 @@ workflow METATDENOVO {
     ch_multiqc_files = ch_multiqc_files.mix(PRE_TRIM_FQC.out.zip.collect{it[1]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(POST_MERGE_FQC.out.zip.collect{it[1]}.ifEmpty([]))
     ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_png.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_html.ifEmpty([]))
+    // Plotly output is buggy, skip for now:
+    // ch_multiqc_files = ch_multiqc_files.mix(COUNTS_PLOT.out.counts_html.ifEmpty([]))
 
 
     MULTIQC (


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the ArkeaBio Code Review Policy: https://docs.google.com/document/d/1yX6rkFrQQhdozEB8OBE9jWsQZgDMw3KS0DLd7MWPEAo/edit#heading=h.tgvpr2mcrxkb
     - 👷‍♀️ Create small PRs. 
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 📗 Analysis
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
I had introduced a bug while trying to keep track of counts moving between the pipeline. This is because I mentioned `${task.id}` inside the task scripts for all of the filtering steps. Each task can have a new id every run, so this violated the hash of the run and meant every run had to restart from scratch more or less.

To simplify this, I now ignore the task id and pipe count results into a CSV, which is now counted by a slightly different `parse_all_counts.R` script.

If you never noticed this behavior, then be glad!

## Jira Task
<!-- 
Link to Jira task.
-->
[CB-48](https://arkeabio.atlassian.net/browse/CB-48)/[CB-224](https://arkeabio.atlassian.net/browse/CB-224) Remove task.index from filter tasks to improve resume

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📕 notebook(s)
- [x] 🙅 no documentation needed

## Code Quality
- [x] 🎯 The code is properly formatted and adheres to the project's style guide
- [x] 🎯 The code runs without any errors or exceptions

## Compute Environment
<!--
Where does this code need to run? Locally? EC2 instance? AWS Batch? Somewhere else?
-->
Wherever is good.

## Testing
<!-- 
Specify how to test the code and where test files are located.
Required for tools/pipelines. 
-->
Test this wherever pipelines are sold. Simply start a run, cancel it after the filtering steps at any point, and use the Nextflow `-resume` flag to restart it. It should pick up where you left off instead of somewhere in Trimmomatic or SortMeRNA.

I did have to disable the cache for transdecoder because it doesn't like being rerun in its work folder, but this isn't related nor is it very noticeable.