### PR TITLE
Cb 231 create one work flow with the mega assembly

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -93,7 +93,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/megahit"},
             mode: 'copy',
-            pattern: '*'
+            pattern: '*/*'
         ]
     }
     

--- a/modules/local/transrate.nf
+++ b/modules/local/transrate.nf
@@ -33,10 +33,10 @@ process TRANSRATE {
 
     mv ${prefix}_transrate/assemblies.csv ${prefix}_assemblies.csv
 
+    transrate --version > version.txt
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        transrate: 1.0.3
+        transrate: \$(cat version.txt)
     END_VERSIONS
     """
-    // transrate isn't getting updated and I can't figure out how to print the version
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,7 @@ params {
     use_names                   = true
     report_zero_counts          = false
     memmapping                  = true
-    confidence                  = 0.01
+    confidence                  = 0.015
     archaea_db                  = null
     no_archaea_db               = null
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -162,7 +162,7 @@
                 },
                 "confidence": {
                     "type": "number",
-                    "default": 0.01,
+                    "default": 0.015,
                     "description": "A scoring value between 0 and 1 that acts as a threshold for labeling an individual sequence a specific taxonomy ID. The classifier will adjust the label up the taxonomic tree until the label meets or exceeds the set threshold.",
                     "fa_icon": "fas fa-crosshairs"
                 },


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the ArkeaBio Code Review Policy: https://docs.google.com/document/d/1yX6rkFrQQhdozEB8OBE9jWsQZgDMw3KS0DLd7MWPEAo/edit#heading=h.tgvpr2mcrxkb
     - 👷‍♀️ Create small PRs. 
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature

## Description
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
The meta-t de novo pipeline can now synthesize all input samples into one mega assembly. It then runs the filtered reads back into itself and reports on all samples. Basically, it does everything. 

## Jira Task
<!-- 
Link to Jira task.
-->
[CB-231](https://arkeabio.atlassian.net/browse/CB-231) Create one work flow with the mega-assembly 🚛
Quick note, Tower _really_ hates emojis in branch names so don't do that anymore, Taylor!!

## Added tests?
- [x] 🙅 no, because they aren't needed

## Added to documentation?
- [x] 🙅 no documentation needed

## Code Quality
- [x] 🎯 The code is properly formatted and adheres to the project's style guide
- [x] 🎯 The code runs without any errors or exceptions

## Compute Environment
<!--
Where does this code need to run? Locally? EC2 instance? AWS Batch? Somewhere else?
-->
Can be run everywhere.

## Testing
<!-- 
Specify how to test the code and where test files are located.
Required for tools/pipelines. 
-->
Testing this on the level that our samples require would be an exorbitant waste, upwards of $7,000. I am tempted to not even do this on samples so large because I'm scared of them breaking and then we don't have much to go on, but we'll see. Perhaps more large scale testing will be possible at some point.

I tested this run with some small (75k reads) data sets on sandbox. You can run that like so:
```
nextflow run main.nf -profile docker \
  --input "/data/meta-t/megasmall.csv" --adapter_fa "/data/meta-t/TruSeq3-PE-2.fa" \
  --indexdir "/data/meta-t/bowtie2_index/" \
  --silva_reference "/data/meta-t/smr_v4.3_default_db.fasta" \
  --rna_idx "/data/meta-t/smr_idx/"  \
  --no_archaea_db "/data/meta-t/kraken2db/no_archaea_db" \
  --eggnogdir "/data/meta-t/eggnog_db/" \
  --hmmdir "/data/meta-t/hmmer_pfam/" --hmmerfile "Pfam-A.hmm" \
  --archaea_db "/data/meta-t/kraken2db/archaea_db/" \
  --outdir "/home/tfalk/arkbio_metatdenovo/results_s/" \
  --split_size 25000 --sandbox --assembler Megahit
```

I am currently running an enormous job with two 208M identical datasets running with one sample, that's [here](https://tower.nf/orgs/ArkeaBio/workspaces/Computational_Biology/watch/OPvJnmnFrWGvr). I am running it on the extremely cheap so it may take a long long time for jobs to be submitted.

I am also worried about the head node becoming swamped if we continue with jobs like this. Perhaps there is a middle ground where we can filter all the samples in separate pipelines and then put the final `fastq`s together for the mega-assembly.

Much to consider, and the feasibility of testing these kinds of changes is growing less and less realistic. I'll make it work though.