### PR TITLE
CB-243 outputs pass into fewer folders for simplicity

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -191,7 +191,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/kraken_bact_out" },
             mode: 'copy',
-            saveAs: { "${task.index}.classified.fastq.gz"},
+            // saveAs: { "${task.index}.classified.fastq.gz"},
             pattern: "*.classified_*"
         ]
     }
@@ -308,7 +308,7 @@ process {
 
     withName: SALMON_MERGE {
         publishDir = [
-            path: {"${params.outdir}/combined_assembly/salmon"},
+            path: {"${params.outdir}/all_samples/salmon/merged"},
             mode: params.publish_dir_mode,
             pattern: '*.sf'
         ]
@@ -316,7 +316,7 @@ process {
 
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/pipeline_info" },
+            path: { "${params.outdir}/pipeline_info" },
             mode: params.publish_dir_mode,
             pattern: '*_versions.yml'
         ]
@@ -324,7 +324,7 @@ process {
 
     withName: CUSTOM_DUMPCOUNTS {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/pipeline_info" },
+            path: { "${params.outdir}/pipeline_info" },
             mode: params.publish_dir_mode,
             pattern: '*.csv'
         ]
@@ -332,7 +332,7 @@ process {
 
     withName: COUNTS_PLOT {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}/pipeline_info" },
+            path: { "${params.outdir}/pipeline_info" },
             mode: params.publish_dir_mode,
             pattern: '*'
         ]

--- a/modules/nf-core/kraken2/main.nf
+++ b/modules/nf-core/kraken2/main.nf
@@ -13,7 +13,7 @@ process KRAKEN2_KRAKEN2 {
     val save_reads_assignment
 
     output:
-    tuple val(meta), path('*.classified{.,_}*')  , optional:true, emit: classified_reads_fastq
+    tuple val(meta), path('*.classified{.,_}*')  , emit: classified_reads_fastq
     tuple val(meta), path('*.unclassified{.,_}*'), emit: unclassified_reads_fastq
     tuple val(meta), path('*classifiedreads.txt'), optional:true, emit: classified_reads_assignment
     tuple val(meta), path('*report.txt')         , emit: report

--- a/modules/nf-core/salmon/merge/main.nf
+++ b/modules/nf-core/salmon/merge/main.nf
@@ -2,7 +2,7 @@ process SALMON_MERGE {
     container "quay.io/biocontainers/salmon:1.10.1--h7e5ed60_0"
 
     input:
-    tuple val(metas), path(quants, stageAs: "?/quant.sf")
+    tuple val(meta), path(quants, stageAs: "?/quant.sf")
 
     output:
     path  "*.sf"                       , emit: quants
@@ -17,7 +17,7 @@ process SALMON_MERGE {
     """
     salmon quantmerge \\
         --quants \$(echo $quants | grep -o "[0-9]\\+/" | awk '\$1=\$1' ORS=' ') \\
-        --names ${metas.collect{ it.id }.join(" ")} \\
+        --names ${meta.collect{ it.id }.join(" ")} \\
         --column numreads \\
         --output salmon_quant_out.sf \\
         $args 


### PR DESCRIPTION
Please see main PR here: https://github.com/Arkea-Bio-Corp/metatdenovo/pull/31

My beautiful son the pipeline has completed another run:
https://tower.nf/orgs/ArkeaBio/workspaces/Computational_Biology/watch/20lmN0J446kU9z

This is the output structure. There is only one sample for this file, sub1M_SRR18336216, so only one sample folder is listed.
![Screenshot 2023-09-19 at 3 13 19 PM](https://github.com/Arkea-Bio-Corp/metatdenovo/assets/131815442/2d2db99c-5c4d-48ed-9241-2f309360c21b)